### PR TITLE
Added a helper for checking if a file is nfc. 

### DIFF
--- a/src/iranlowo/adr.py
+++ b/src/iranlowo/adr.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import pkg_resources
 import re
 import unicodedata
+from pathlib import Path
 
 from argparse import Namespace
 from collections import defaultdict
@@ -45,6 +46,21 @@ def strip_accents_file(filename, outfilename):
         with f:
             f.write(strip_accents_text(text))
         return True
+
+
+def is_file_nfc(path):
+    """
+
+    Args:
+        path: File path
+
+    Returns: True if file is valid nfc and False if not. Raises a ValueError if path is not correct
+
+    """
+    if Path(path).is_file():
+        text = open(path).read()
+        return is_text_nfc(text)
+    raise FileNotFoundError("{0} is not a valid file path".format(path))
 
 
 def is_text_nfc(text):
@@ -221,14 +237,14 @@ def split_corpus_on_symbol(filename, outfilename, symbol=","):
                         break
                     if num_words >= min_words_to_split:
                         if (
-                            num_words_ahead_of_curr_comma >= min_words_in_utt
-                            and len((curr_line)[curr_comma_position:].split())
-                            >= min_words_in_utt
+                                num_words_ahead_of_curr_comma >= min_words_in_utt
+                                and len((curr_line)[curr_comma_position:].split())
+                                >= min_words_in_utt
                         ):
                             f.write((curr_line)[0:curr_comma_position] + "\n")
 
                             # update vars
-                            curr_line = curr_line[curr_comma_position + 1 :]
+                            curr_line = curr_line[curr_comma_position + 1:]
                             num_words = len(curr_line.split())
                             num_commas = num_commas - 1
                             if num_commas > 0:
@@ -243,8 +259,8 @@ def split_corpus_on_symbol(filename, outfilename, symbol=","):
                             num_commas = num_commas - 1
                             if num_commas > 0:  # for say 3 commas
                                 curr_comma_position += (
-                                    curr_line[curr_comma_position + 1 :].index(symbol)
-                                    + 1
+                                        curr_line[curr_comma_position + 1:].index(symbol)
+                                        + 1
                                 )
                                 num_words_ahead_of_curr_comma = len(
                                     curr_line[0:curr_comma_position].split()
@@ -258,7 +274,6 @@ def split_corpus_on_symbol(filename, outfilename, symbol=","):
 
 
 def diacritize_text(undiacritized_text, verbose=False):
-
     # manually construct the options so we don't have to pass them in.
     opt = Namespace()
     opt.alpha = 0.0
@@ -329,9 +344,11 @@ def diacritize_text(undiacritized_text, verbose=False):
 
 
 if __name__ == "__main__":
-
-    # test
+    # # test
     print(is_text_nfc("Kílódé, ṣèbí àdúrà le̩ fé̩ gbà nbẹ?"))  # NFD
     print(is_text_nfc("Kílódé, ṣèbí àdúrà le̩ fé̩ gbà nbẹ?"))  # NFC
+    print(is_file_nfc('/Users/Olamilekan/Desktop/Machine Learning/OpenSource/yoruba-text/Book_of_Mormon/cleaned/doctrine_and_covenants.txt'))
 
-    file_info("../../tests/testdata/nfc.txt")
+    print(is_file_nfc('/Users/Olamilekan/Desktop/Machine Learning/OpenSource/yoruba-text/Owe/yoruba_proverbs_out.txt'))
+
+    # file_info("../../tests/testdata/nfc.txt")

--- a/tests/test_adr.py
+++ b/tests/test_adr.py
@@ -26,6 +26,14 @@ def test_strip_accents_file():
     assert(filecmp.cmp(reference_stripped_filepath, processed_stripped_filepath))   # processed matches reference
 
 
+def test_is_file_nfc():
+    cwd = os.getcwd()
+    src_filepath_pass = cwd + "/testdata/nfc.txt"
+    src_filepath_fail = cwd + "/testdata/nfc_fail.txt"
+    assert (ránlọ.is_file_nfc(src_filepath_pass) is True)
+    assert (ránlọ.is_file_nfc(src_filepath_fail) is False)
+
+
 def test_is_text_nfc():
     assert(ránlọ.is_text_nfc("Kílódé, ṣèbí àdúrà le̩ fé̩ gbà nbẹ?") is False)  # NFD
     assert(ránlọ.is_text_nfc("Kílódé, ṣèbí àdúrà le̩ fé̩ gbà nbẹ?") is True)   # NFC

--- a/tests/test_adr.py
+++ b/tests/test_adr.py
@@ -28,8 +28,8 @@ def test_strip_accents_file():
 
 def test_is_file_nfc():
     cwd = os.getcwd()
-    src_filepath_pass = cwd + "/testdata/nfc.txt"
-    src_filepath_fail = cwd + "/testdata/nfc_fail.txt"
+    src_filepath_pass = cwd + "/tests/testdata/nfc.txt"
+    src_filepath_fail = cwd + "/tests/testdata/nfc_fail.txt"
     assert (ránlọ.is_file_nfc(src_filepath_pass) is True)
     assert (ránlọ.is_file_nfc(src_filepath_fail) is False)
 

--- a/tests/testdata/nfc_fail.txt
+++ b/tests/testdata/nfc_fail.txt
@@ -1,0 +1,10 @@
+<h4>1</h4>
+ Nífáì bẹ̀rẹ̀ ìwé ìrántí àwọn ènìyàn rẹ̀—Léhì ríran rí ọwọ̀n iná kan ó sì kà láti inú ìwé ìsọtẹ́lẹ̀ kan—Ó yin Ọlọ́run, ó sọ nípa bíbọ̀ Messia nã, ó sì sọtẹ́lẹ̀ nípa ìparun Jerúsálẹ́mù—A ṣe inúnibíni sí i nípasẹ̀ àwọn Jũ. Ní ìwọ̀n ọdún 600 kí á tó bí Olúwa wa. ÈMI, Nífáì, nítorí tí a bí mi nípa àwọn òbí dídára, nítorínã a kọ́ mi nínú gbogbo òye bàbá mi; àti nítorí pé mo ti rí ọ̀pọ̀lọpọ̀ ìpọ́njú ní ìgbà àwọn ọjọ́ mi, bíótilẹ̀ríbẹ̃, nítorí tí mo ti rí ojúrere Olúwa lọ́pọ̀ ní gbogbo àwọn ọjọ́ mi; bẹ̃ni, nítorí pé mo ti ní ìmọ̀ nla nípa ọ́re àti àwọn ohun ìjìnlẹ̀ Ọlọ́run, nítorínã mo ṣe ìwé ìrántí àwọn ìṣe mi ní àwọn ọjọ́ mi.
+<h5>2</h5>
+Bẹ̃ni, mo ṣe ìwé ìrántí ní èdè
+ bàbá mi, èyí tí ó ní òye àwọn Jũ àti èdè àwọn ará Égíptì.
+<h5>3</h5>
+Mo sì mọ̀ wí pé ìwé ìrántí èyí
+ tí mo ṣe jẹ́ òtítọ́; mo sì ṣe é pẹ̀lú ọwọ́ ara mi; mo sì ṣe é gẹ́gẹ́ bí ìmọ̀ mi.
+<h5>4</h5>
+Ó sì ṣe ní ìbẹ̀rẹ̀ ọdún kíní


### PR DESCRIPTION
While attending to https://github.com/Niger-Volta-LTI/yoruba-text/issues/17, I noticed I had to read the file myself first before calling the nfc checker on it. 
I decided to add a new function `is_file_nfc` to read files and then do the check automatically. This is not exactly major addition right now but I imagine it'll be when we start getting very large files. Then I can rewrite the function to handle various supported formats.