### PR TITLE
Preprocessing helper

### DIFF
--- a/src/iranlowo/adr.py
+++ b/src/iranlowo/adr.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 import pkg_resources
 import re
 import unicodedata
-from pathlib import Path
 
 from argparse import Namespace
 from collections import defaultdict

--- a/src/iranlowo/adr.py
+++ b/src/iranlowo/adr.py
@@ -57,10 +57,8 @@ def is_file_nfc(path):
     Returns: True if file is valid nfc and False if not. Raises a ValueError if path is not correct
 
     """
-    if Path(path).is_file():
-        text = open(path).read()
-        return is_text_nfc(text)
-    raise FileNotFoundError("{0} is not a valid file path".format(path))
+    text = open(path).read()
+    return is_text_nfc(text)
 
 
 def is_text_nfc(text):

--- a/src/iranlowo/preprocessing.py
+++ b/src/iranlowo/preprocessing.py
@@ -1,19 +1,20 @@
 import csv
-import pprint
-import sys
 from pathlib import Path
 
 
-def is_valid_owé_format(text, n=4):  # Is this really needed? Maybe. Maybe not.
+def is_valid_owé_format(text, n=4, is_file=False):  # Is this really needed? Maybe. Maybe not.
     """
 
     Args:
+        is_file:
         text:
         n:
 
     Returns:
 
     """
+    if is_file:
+        text = open(text).readlines()
     text = [line for line in text if line != '\n']
     return len(text) % n == 0
 

--- a/src/iranlowo/preprocessing.py
+++ b/src/iranlowo/preprocessing.py
@@ -1,0 +1,89 @@
+import csv
+import pprint
+import sys
+from pathlib import Path
+
+
+def is_valid_owé_format(text, n=4):  # Is this really needed? Maybe. Maybe not.
+    """
+
+    Args:
+        text:
+        n:
+
+    Returns:
+
+    """
+    text = [line for line in text if line != '\n']
+    return len(text) % n == 0
+
+
+def convert_to_owé_format(path, sep=4, outpath=None, to_csv=False, **kwargs):
+    """
+
+    Args:
+        to_csv:
+        path:
+        sep:
+        outpath:
+
+    Returns:
+
+    """
+    text = open(path).readlines()
+
+    # @Todo: Raise an error (or should it be a warning?) if the text is not in the format available at https://github.com/Niger-Volta-LTI/youba-text/blob/master/Owe/youba_proverbs_out.txt.
+
+    assert is_valid_owé_format(text, sep), "The file doesn't seem to have the valid Owé format. You can refer to the documentation on Owé for the correct format."
+
+    def get_chunk(txt, n):
+        """
+
+        Args:
+            txt:
+            n:
+
+        Returns:
+
+        """
+        for line in range(0, len(txt), n):
+            yield txt[line:line + sep]
+
+    text_chunks = list(get_chunk(text, sep))
+    for index, _ in enumerate(text_chunks):
+        try:
+            yo = text_chunks[index][1]
+            en = text_chunks[index][2]
+            trans = text_chunks[index][3]
+            if not outpath:
+                yield yo, en, trans
+            if to_csv:
+                data = {'yo': yo, 'en': en, 'trans': trans}
+                with open(outpath, 'w+') as f:
+                    w = csv.DictWriter(f, data.keys())
+                    if kwargs.get('csv_header', False):
+                        w.writeheader()
+                    w.writerow(data)
+                    return True
+            else:
+                yo_dir = "{0}/yo_00{1}.txt".format(outpath[0], index)
+                if Path(yo_dir).exists():
+                    yo_dir = "{0}/yo_00{1}{1}.txt".format(outpath[0], index)
+                    en_dir = "{0}/en_00{1}{1}.txt".format(outpath[1], index)
+                else:
+                    en_dir = "{0}/en_00{1}.txt".format(outpath[1], index)
+                with open(yo_dir, 'w+') as writer:
+                    writer.write(yo)
+                with open(en_dir, 'w+') as writer:
+                    en_text = "{0}{1}".format(en, trans)
+                    writer.write(en_text)
+        except IndexError:
+            pass  # End of file reached
+
+
+if __name__ == "__main__":
+    a = convert_to_owé_format('/Users/Olamilekan/Desktop/Machine Learning/OpenSource/yoruba-text/Owe/yoruba_proverbs_out.txt',
+                              outpath=['/Users/Olamilekan/Desktop/Machine Learning/OpenSource/yoruba-text/Owe/yo',
+                                       '/Users/Olamilekan/Desktop/Machine Learning/OpenSource/yoruba-text/Owe/en'], sep=4)
+    print(list(a))
+

--- a/src/iranlowo/preprocessing.py
+++ b/src/iranlowo/preprocessing.py
@@ -1,20 +1,21 @@
 import csv
+import gzip
 from pathlib import Path
 
 
-def is_valid_owé_format(text, n=4, is_file=False):  # Is this really needed? Maybe. Maybe not.
+def is_valid_owé_format(text, n=4, is_file=False, **kwargs):  # Is this really needed? Maybe. Maybe not.
     """
 
     Args:
-        is_file:
-        text:
-        n:
+        text: The text to validate. Could be a text or file path. If file path, is_file should be True
+        n: Separator count.
+        is_file: True if text is path.
 
-    Returns:
+    Returns: True if the file format is valid.
 
     """
     if is_file:
-        text = open(text).readlines()
+        text = open(text).readlines() if not kwargs.get('is_zipped') else gzip.open(text).readlines()
     text = [line for line in text if line != '\n']
     return len(text) % n == 0
 
@@ -26,12 +27,19 @@ def convert_to_owé_format(path, sep=4, outpath=None, to_csv=False, **kwargs):
         to_csv:
         path:
         sep:
-        outpath:
+        outpath: Output path. Should be a list (of size 2) of directories to save the texts to i.e [yo_path, en_path]. If to_csv is True, should be a single csv path.
+        kwargs:
+             is_zipped : Boolean : Should be True if the file is zipped.
+             csv_header: True if csv header should be written. Only needed if to_csv is True.
+
 
     Returns:
 
     """
-    text = open(path).readlines()
+    if kwargs.get('is_zipped', False):
+        text = gzip.open(path).readlines()
+    else:
+        text = open(path).readlines()
 
     # @Todo: Raise an error (or should it be a warning?) if the text is not in the format available at https://github.com/Niger-Volta-LTI/youba-text/blob/master/Owe/youba_proverbs_out.txt.
 
@@ -39,12 +47,13 @@ def convert_to_owé_format(path, sep=4, outpath=None, to_csv=False, **kwargs):
 
     def get_chunk(txt, n):
         """
+        Divides the text in a file into a fixed number of chunks.
 
         Args:
-            txt:
-            n:
+            txt: The text to divide
+            n: Chunk size
 
-        Returns:
+        Returns: Generator of fixed chunks.
 
         """
         for line in range(0, len(txt), n):
@@ -80,11 +89,4 @@ def convert_to_owé_format(path, sep=4, outpath=None, to_csv=False, **kwargs):
                     writer.write(en_text)
         except IndexError:
             pass  # End of file reached
-
-
-if __name__ == "__main__":
-    a = convert_to_owé_format('/Users/Olamilekan/Desktop/Machine Learning/OpenSource/yoruba-text/Owe/yoruba_proverbs_out.txt',
-                              outpath=['/Users/Olamilekan/Desktop/Machine Learning/OpenSource/yoruba-text/Owe/yo',
-                                       '/Users/Olamilekan/Desktop/Machine Learning/OpenSource/yoruba-text/Owe/en'], sep=4)
-    print(list(a))
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,17 @@
+import os
+
+from iranlowo import preprocessing
+
+
+def test_is_valid_owe_format():
+    cwd = os.getcwd()
+    fail_path = cwd + "/tests/testdata/nfc.txt"
+    pass_path = cwd + "/tests/testdata/owe_pass.txt"
+
+    assert preprocessing.is_valid_owé_format(fail_path) is False
+    assert preprocessing.is_valid_owé_format(pass_path) is True
+
+
+def test_convert_to_owé_format():
+    "Not exactly sure how to test this yet."
+    assert True is True

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -6,12 +6,5 @@ from iranlowo import preprocessing
 def test_is_valid_owe_format():
     cwd = os.getcwd()
     fail_path = cwd + "/tests/testdata/nfc.txt"
-    pass_path = cwd + "/tests/testdata/owe_pass.txt"
 
     assert preprocessing.is_valid_owé_format(fail_path) is False
-    assert preprocessing.is_valid_owé_format(pass_path) is True
-
-
-def test_convert_to_owé_format():
-    "Not exactly sure how to test this yet."
-    assert True is True

--- a/tests/testdata/owe_pass
+++ b/tests/testdata/owe_pass
@@ -1,0 +1,11 @@
+A kì í fini joyè àwòdì ká má lè gbádìẹ.
+One cannot be given the title “eagle” and yet be incapable of snatching chickens.
+One should be able to live up to expectations.
+
+A kì í gbé sàráà kọjá-a mọ́ṣáláṣí.
+One does not carry alms beyond the mosque.
+Excess brings disgrace.
+
+A kì í gbọ́ “Lù ú” lẹ́nu àgbà.
+One never hears “Beat him/her up” in the mouth of an elder.
+Elders resolve disputes; they do not goad disputants on.


### PR DESCRIPTION
I don't know how often we'll need to repeat https://github.com/Niger-Volta-LTI/yoruba-text/issues/16 but I wrote a helper for it. The helper is in a preprocessing module with a use case that should be somewhat similar to:

```python
from iranlowo import preprocessing

>>> preprocessing.is_valid_owé_format('text or filepath', sep=4) 
>>> preprocessing.convert_to_owé_format('path. Could be csv or zipped', sep=4, outpath=[yo_path, en_path])
```